### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/lib/dotPath.js
+++ b/lib/dotPath.js
@@ -57,7 +57,7 @@ function walk( object , pathArray ) {
 		pointer = object ;
 
 	for ( i = 0 , iMax = pathArray.length ; i < iMax ; i ++ ) {
-		if ( ! pointer || ( typeof pointer !== 'object' && typeof pointer !== 'function' ) ) {
+		if ( ! pointer || ( typeof pointer !== 'object' && typeof pointer !== 'function' ) || isPrototypePolluted(pathArray[i]) ) {
 			return undefined ;
 		}
 
@@ -98,7 +98,7 @@ function pave( object , pathArray ) {
 	for ( i = 0 , iMax = pathArray.length - 1 ; i < iMax ; i ++ ) {
 		key = pathArray[ i ] ;
 
-		if ( ! pointer[ key ] || ( typeof pointer[ key ] !== 'object' && typeof pointer[ key ] !== 'function' ) ) {
+		if ( ! pointer[ key ] || ( typeof pointer[ key ] !== 'object' && typeof pointer[ key ] !== 'function' ) || isPrototypePolluted(key) ) {
 			pointer[ key ] = {} ;
 		}
 
@@ -108,6 +108,10 @@ function pave( object , pathArray ) {
 	return pointer ;
 }
 
+// Blacklist certain keys to prevent Prototype Pollution
+function isPrototypePolluted(key) {
+    return /__proto__|constructor|prototype/.test(key);
+}
 
 
 dotPath.get = function( object , path ) {

--- a/lib/path.js
+++ b/lib/path.js
@@ -146,7 +146,8 @@ treePath.op = function op( type , object , path , value ) {
 			continue ;
 		}
 		else if ( isPrototypePolluted(parts[i]) ) {
-			continue;
+			pointer = {} ;
+			continue ;
 		}
 
 		canBeEmpty = false ;

--- a/lib/path.js
+++ b/lib/path.js
@@ -145,6 +145,9 @@ treePath.op = function op( type , object , path , value ) {
 			canBeEmpty = false ;
 			continue ;
 		}
+		else if ( isPrototypePolluted(parts[i]) ) {
+			continue;
+		}
 
 		canBeEmpty = false ;
 
@@ -234,7 +237,10 @@ treePath.op = function op( type , object , path , value ) {
 	}
 } ;
 
-
+// Blacklist certain keys to prevent Prototype Pollution
+function isPrototypePolluted(key) {
+    return /__proto__|constructor|prototype/.test(key);
+}
 
 // get, set and delete use the same op() function
 treePath.get = treePath.op.bind( undefined , 'get' ) ;


### PR DESCRIPTION
### :bar_chart: Metadata *

`tree-kit` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-tree-kit

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const { dotPath } = require('tree-kit')

console.log(`Before: ${{}.polluted}`)
dotPath.set({}, '__proto__.polluted', true)
console.log(`After: ${{}.polluted}`)
```
2. Execute the following commands in terminal:
```bash
npm i tree-kit # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/105367346-5b95f900-5c26-11eb-818b-3749ee7c59f8.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
